### PR TITLE
Faster respawn option

### DIFF
--- a/Configuration/Server/StandardServerConfig.cs
+++ b/Configuration/Server/StandardServerConfig.cs
@@ -32,11 +32,10 @@ namespace AdLibitum.Configuration.Server
             [LibitumLabel("Config.Option.RespawnTimeModifier.Label")]
             [LibitumTooltip("Config.Option.RespawnTimeModifier.Tooltip")]
             [Slider]
-            [Range(1, 10)]
-            [Increment(1f)]
-            [DrawTicks]
-            [DefaultValue(1f)]
-            public int RespawnTimeModifier = 1;
+            [Range(0, 200)]
+            [Increment(1)]
+            [DefaultValue(100)]
+            public int RespawnTimeModifier = 100;
         }
 
         [LibitumLabel("Config.Page.ItemToggles")]

--- a/Configuration/Server/StandardServerConfig.cs
+++ b/Configuration/Server/StandardServerConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Terraria.ModLoader.Config;
 
 namespace AdLibitum.Configuration.Server
@@ -32,10 +33,15 @@ namespace AdLibitum.Configuration.Server
             [LibitumLabel("Config.Option.RespawnTimeModifier.Label")]
             [LibitumTooltip("Config.Option.RespawnTimeModifier.Tooltip")]
             [Slider]
-            [Range(0, 200)]
-            [Increment(1)]
-            [DefaultValue(100)]
-            public int RespawnTimeModifier = 100;
+            [Range(0f, 2f)]
+            [Increment(0.1f)]
+            [DefaultValue(1f)]
+            public float RespawnTimeModifier {
+                get => respawnTimeModifier;
+                set => respawnTimeModifier = (float)Math.Round((float)value, 1);
+            }
+
+            private float respawnTimeModifier;
         }
 
         [LibitumLabel("Config.Page.ItemToggles")]

--- a/Configuration/Server/StandardServerConfig.cs
+++ b/Configuration/Server/StandardServerConfig.cs
@@ -28,6 +28,15 @@ namespace AdLibitum.Configuration.Server
             [LibitumTooltip("Config.Option.BossBagSellPriceAveraging.Tooltip")]
             [DefaultValue(true)]
             public bool BossBagSellPriceAveraging = true;
+
+            [LibitumLabel("Config.Option.RespawnTimeModifier.Label")]
+            [LibitumTooltip("Config.Option.RespawnTimeModifier.Tooltip")]
+            [Slider]
+            [Range(1, 10)]
+            [Increment(1f)]
+            [DrawTicks]
+            [DefaultValue(1f)]
+            public int RespawnTimeModifier = 1;
         }
 
         [LibitumLabel("Config.Page.ItemToggles")]

--- a/Content/Tweaks/RespawnTimeModifier/RespawnTimeModifierPlayer.cs
+++ b/Content/Tweaks/RespawnTimeModifier/RespawnTimeModifierPlayer.cs
@@ -1,0 +1,37 @@
+﻿using AdLibitum.Configuration.Server;
+using System;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+
+namespace AdLibitum.Content.Tweaks.RespawnTimeModifier
+{
+    public class RespawnTimeModifierPlayer : ModPlayer
+    {
+        public override void UpdateDead() {
+            if (AmICloseToRespawnTimeAffectingBoss())
+                return;
+
+            int targetRespawnTime = MaxRespawnTime() / StandardServerConfig.Config.Tweaks.RespawnTimeModifier;
+            if (Player.respawnTimer > targetRespawnTime)
+                Player.respawnTimer = targetRespawnTime;
+        }
+
+        private int MaxRespawnTime() => (int) (600f * (Main.expertMode ? 1.5f : 1f));
+
+        private bool AmICloseToRespawnTimeAffectingBoss() {
+            // From Player.KillMe
+            for (int k = 0; k < 200; k++)
+            {
+                if (Main.npc[k].active &&
+                    (Main.npc[k].boss || Main.npc[k].type == NPCID.EaterofWorldsHead || Main.npc[k].type == NPCID.EaterofWorldsBody || Main.npc[k].type == NPCID.EaterofWorldsTail)
+                    && Math.Abs(Player.Center.X - Main.npc[k].Center.X) + Math.Abs(Player.Center.Y - Main.npc[k].Center.Y) < 4000f)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Content/Tweaks/RespawnTimeModifier/RespawnTimeModifierPlayer.cs
+++ b/Content/Tweaks/RespawnTimeModifier/RespawnTimeModifierPlayer.cs
@@ -12,12 +12,20 @@ namespace AdLibitum.Content.Tweaks.RespawnTimeModifier
             if (AmICloseToRespawnTimeAffectingBoss())
                 return;
 
-            int targetRespawnTime = MaxRespawnTime() / StandardServerConfig.Config.Tweaks.RespawnTimeModifier;
-            if (Player.respawnTimer > targetRespawnTime)
+            int respawnTimeMod = StandardServerConfig.Config.Tweaks.RespawnTimeModifier;
+
+            // 0 / 100 == 1
+            if (respawnTimeMod == 0)
+                Player.respawnTimer = 0;
+
+            int targetRespawnTime = (int)(MaxRespawnTime() * (respawnTimeMod / 100f));
+
+            if ((Player.respawnTimer > targetRespawnTime && respawnTimeMod > 100) ||
+                (Player.respawnTimer < targetRespawnTime && respawnTimeMod < 100))
                 Player.respawnTimer = targetRespawnTime;
         }
 
-        private int MaxRespawnTime() => (int) (600f * (Main.expertMode ? 1.5f : 1f));
+        private float MaxRespawnTime() => 600f * (Main.expertMode ? 1.5f : 1f);
 
         private bool AmICloseToRespawnTimeAffectingBoss() {
             // From Player.KillMe

--- a/Content/Tweaks/RespawnTimeModifier/RespawnTimeModifierPlayer.cs
+++ b/Content/Tweaks/RespawnTimeModifier/RespawnTimeModifierPlayer.cs
@@ -3,29 +3,26 @@ using System;
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.ID;
+using Terraria.DataStructures;
 
 namespace AdLibitum.Content.Tweaks.RespawnTimeModifier
 {
     public class RespawnTimeModifierPlayer : ModPlayer
     {
-        public override void UpdateDead() {
+        public override void Kill(double damage, int hitDirection, bool pvp, PlayerDeathReason damageSource) {
             if (AmICloseToRespawnTimeAffectingBoss())
                 return;
 
-            int respawnTimeMod = StandardServerConfig.Config.Tweaks.RespawnTimeModifier;
+            float respawnTimeMod = StandardServerConfig.Config.Tweaks.RespawnTimeModifier;
 
-            // 0 / 100 == 1
+            // 0 / 1 == 1
             if (respawnTimeMod == 0)
                 Player.respawnTimer = 0;
 
-            int targetRespawnTime = (int)(MaxRespawnTime() * (respawnTimeMod / 100f));
+            int targetRespawnTime = (int) (Player.respawnTimer * (respawnTimeMod));
 
-            if ((Player.respawnTimer > targetRespawnTime && respawnTimeMod > 100) ||
-                (Player.respawnTimer < targetRespawnTime && respawnTimeMod < 100))
-                Player.respawnTimer = targetRespawnTime;
+            Player.respawnTimer = targetRespawnTime;
         }
-
-        private float MaxRespawnTime() => 600f * (Main.expertMode ? 1.5f : 1f);
 
         private bool AmICloseToRespawnTimeAffectingBoss() {
             // From Player.KillMe

--- a/Localization/en-US.toml
+++ b/Localization/en-US.toml
@@ -36,6 +36,9 @@ MaxBuffSlots.Tooltip = "Configures the maximum amount of buffs a player may use.
 BossBagSellPriceAveraging.Label = "Treasure Bag Sell Price Averaging"
 BossBagSellPriceAveraging.Tooltip = "If enabled, Treasure Bags will have their sell prices auto-generated from the average sell price of their contents.\nThe price may vary slightly when reloaded."
 
+RespawnTimeModifier.Label = "Respawn Time Modifier"
+RespawnTimeModifier.Tooltip = "Makes you respawn x times faster.\nFor example, setting this option to 2 makes you respawn 2 times faster.\nDoes not take effect during boss fights."
+
 
 # ITEM TOGGLES
 PortableStorages.Label = "Portable Storages"

--- a/Localization/en-US.toml
+++ b/Localization/en-US.toml
@@ -36,8 +36,8 @@ MaxBuffSlots.Tooltip = "Configures the maximum amount of buffs a player may use.
 BossBagSellPriceAveraging.Label = "Treasure Bag Sell Price Averaging"
 BossBagSellPriceAveraging.Tooltip = "If enabled, Treasure Bags will have their sell prices auto-generated from the average sell price of their contents.\nThe price may vary slightly when reloaded."
 
-RespawnTimeModifier.Label = "Respawn Time Modifier"
-RespawnTimeModifier.Tooltip = "A percent modifier to your respawn time.\nDoes not take effect during boss fights."
+RespawnTimeModifier.Label = "Respawn Time Multiplier"
+RespawnTimeModifier.Tooltip = "A multiplier to the time it takes to respawn.\nDoes not take effect during boss fights."
 
 
 # ITEM TOGGLES

--- a/Localization/en-US.toml
+++ b/Localization/en-US.toml
@@ -37,7 +37,7 @@ BossBagSellPriceAveraging.Label = "Treasure Bag Sell Price Averaging"
 BossBagSellPriceAveraging.Tooltip = "If enabled, Treasure Bags will have their sell prices auto-generated from the average sell price of their contents.\nThe price may vary slightly when reloaded."
 
 RespawnTimeModifier.Label = "Respawn Time Modifier"
-RespawnTimeModifier.Tooltip = "Makes you respawn x times faster.\nFor example, setting this option to 2 makes you respawn 2 times faster.\nDoes not take effect during boss fights."
+RespawnTimeModifier.Tooltip = "A percent modifier to your respawn time.\nDoes not take effect during boss fights."
 
 
 # ITEM TOGGLES


### PR DESCRIPTION
Adds a config option to make you respawn faster. To quote the tooltip:
> A percent modifier to your respawn time)
> Does not take effect during boss fights.

This option goes up in increments of 1 and can go anywhere from 0 (instant) to 200 (2x slow). It defaults to 100 (normal speed).